### PR TITLE
adds grunt build task to min and move css to styleguide/public

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,4 +83,5 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-cssmin');
 
   grunt.registerTask('default', ['browserSync','watch:css']);
+  grunt.registerTask('build', ['sass','cssmin','copy:min']);
 }


### PR DESCRIPTION
Just run `grunt build` in your script after building the styleguide to ensure styles.min.css is served up
