### PR TITLE
fixes a small glitch with snap menu

### DIFF
--- a/source/scss/blocks/_snap.scss
+++ b/source/scss/blocks/_snap.scss
@@ -34,7 +34,7 @@ snap-drawer {
 }
 
 .snap-drawer {
-  @media screen and (min-width:$snap-menu-breaking-point-1) {
+  @media screen and (min-width:$snap-menu-breaking-point) {
     display: none;
   }
 }


### PR DESCRIPTION
Snap menu wasn't showing up when window size was exactly 999px. Caught it by accident, glad I did.
