### PR TITLE
remove grunt-kss from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-kss": "^2.0.0",
     "grunt-postcss": "^0.7.0",
     "grunt-sass": "^1.1.0",
     "kss": "^2.1.0",


### PR DESCRIPTION
This was causing a build error and is not a dependency we are using.
