### PR TITLE
Changes dropdown items to highlight on focus, removes focus outline

### DIFF
--- a/source/scss/elements/_form.scss
+++ b/source/scss/elements/_form.scss
@@ -452,10 +452,11 @@ select.cui-select,
 .cui-dropdown__item {
   padding: em(10) em(30);
 
-  &:hover {
+  &:focus {
     background-color: $cui-primary-colors--medium-dark;
     color: #fff;
     cursor: pointer;
+    outline: 0;
   }
 }
 


### PR DESCRIPTION
- Dropdown items will now apply styles on focus instead of hover.
- Removes outline when dropdown items are focused.